### PR TITLE
M4 - V0.10.0 public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Table of Contents
 
+- **[r1.3](#r13)**
 - **[r1.2](#r12)**
 - **[r1.1](#r11)**
 
@@ -14,6 +15,51 @@ The below sections record the changes for each API version in each release as fo
 * for the first release-candidate, all changes since the last public release
 * for subsequent release-candidate(s), only the delta to the previous release-candidate
 * for a public release, the consolidated changes since the previous public release
+
+# r1.3
+
+## Release Notes
+
+This pre-release contains the definition and documentation of:
+* traffic-influence v0.10.0
+
+The API definition(s) are based on
+* Commonalities v0.6.0
+* Identity and Consent Management v0.4.0
+
+## traffic-influence v0.10.0
+This is a public release for the CAMARA Traffic Influence API. This version provides the ability to influence the traffic flow from the user device toward the Edge instance of the Application providing the optimal routing.
+The traffic can be influenced even when the user device moves to a different geographical location to always get the optimal routing toward the nearer instance of an Application..
+
+- API definition **with inline documentation**:
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/TrafficInfluence/blob/r1.3/code/API_definitions/traffic-influence.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/TrafficInfluence/r1.3/code/API_definitions/traffic-influence.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/TrafficInfluence/r1.3/code/API_definitions/traffic-influence.yaml)
+
+## Please note:
+
+- This pre-release contains a release-candidate API version, there are bug fixes to be expected and incompatible changes in upcoming versions 
+- The release is suitable for implementers, but it is not recommended to use the API with customers in productive environments
+- The release scope is defined here: https://github.com/camaraproject/TrafficInfluence/issues/14
+
+### Added
+* Support for the following use cases: https://github.com/camaraproject/TrafficInfluence/discussions/15
+    
+### Changed
+* x-correlator update: https://github.com/camaraproject/TrafficInfluence/pull/49
+* Alignment with the CAMARA Error codes: https://github.com/camaraproject/TrafficInfluence/pull/53
+* Updated the name of the test file to be coherent with the operationId: https://github.com/camaraproject/TrafficInfluence/pull/53
+* ErrorInfo scheme updated: https://github.com/camaraproject/TrafficInfluence/pull/65
+
+### Fixed
+* Backslash \ is not standard markdown syntax for paragraph: https://github.com/camaraproject/TrafficInfluence/pull/53
+* info.description reordering: https://github.com/camaraproject/TrafficInfluence/pull/62
+* Path in Background section: https://github.com/camaraproject/TrafficInfluence/pull/62
+* DeviceResponse description updated: https://github.com/camaraproject/TrafficInfluence/pull/65
+
+### Removed
+
+**Full Changelog**: https://github.com/camaraproject/TrafficInfluence/compare/r1.1...r1.3
 
 # r1.2
 
@@ -28,7 +74,7 @@ The API definition(s) are based on
 
 ## traffic-influence v0.10.0-rc.1
 This is the release candidate for the CAMARA Traffic Influence API. This version provides the ability to influence the traffic flow from the user device toward the Edge instance of the Application providing the optimal routing.
-The traffic can be influencend even when the user device moves to a different geographical location to always get the optimal routing toward the nearer instance of an Application..
+The traffic can be influenced even when the user device moves to a different geographical location to always get the optimal routing toward the nearer instance of an Application..
 
 - API definition **with inline documentation**:
   - OpenAPI [YAML spec file](https://github.com/camaraproject/TrafficInfluence/blob/r1.2/code/API_definitions/traffic-influence.yaml)
@@ -44,19 +90,15 @@ The traffic can be influencend even when the user device moves to a different ge
 ### Added
   
 ### Changed
-
-* Renamed operations: https://github.com/camaraproject/EnergyFootprintNotification/pull/83 
-* Changed OAuth2 with OpenId: https://github.com/camaraproject/EnergyFootprintNotification/pull/83
-* Updated the name of the test file to be coherent with the operationId: https://github.com/camaraproject/EnergyFootprintNotification/pull/83
 * x-correlator update: https://github.com/camaraproject/TrafficInfluence/pull/49
 * Alignment with the CAMARA Error codes: https://github.com/camaraproject/TrafficInfluence/pull/53
 * Updated the name of the test file to be coherent with the operationId: https://github.com/camaraproject/TrafficInfluence/pull/53
 
 ### Fixed
-
+* Backslash \ is not standard markdown syntax for paragraph: https://github.com/camaraproject/TrafficInfluence/pull/53
 ### Removed
 
-**Full Changelog**: https://github.com/camaraproject/TrafficInfluence/commits/r1.1...r1.2
+**Full Changelog**: https://github.com/camaraproject/TrafficInfluence/compare/r1.1...r1.2
 
 # r1.1
 
@@ -71,7 +113,7 @@ The API definition(s) are based on
 
 ## traffic-influence v0.9.0-alpha.1
 This is an alpha release of the CAMARA Traffic Influence API v0.9.0. This version provides the ability to influence the traffic flow from the user device toward the Edge instance of the Application providing the optimal routing.
-The traffic can be influencend even when the user device moves to a different geographical location to always get the optimal routing toward the nearer instance of an Application..
+The traffic can be influenced even when the user device moves to a different geographical location to always get the optimal routing toward the nearer instance of an Application..
 
 - API definition **with inline documentation**:
   - OpenAPI [YAML spec file](https://github.com/camaraproject/TrafficInfluence/blob/r1.1/code/API_definitions/traffic-influence.yaml)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Sandbox API Repository to describe, develop, document, and test the TrafficInflu
 ## Release Information
 Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
 
-* **NEW**: Pre-release [r1.2](https://github.com/camaraproject/TrafficInfluence/releases/tag/r1.2). with traffic-influence v0.10.0-rc.1 is available.
+* `NEW`: The latest public release is [r1.3](https://github.com/camaraproject/TrafficInfluence/releases/tag/r1.3) with traffic-influence v0.10.0
+- API definition **with inline documentation**:
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/TrafficInfluence/blob/r1.3/code/API_definitions/traffic-influence.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/TrafficInfluence/r1.3/code/API_definitions/traffic-influence.yaml&nocors)
+  - [View it on Swagger Editor](https://camaraproject.github.io/swagger-ui/?url=https://raw.githubusercontent.com/camaraproject/TrafficInfluence/r1.3/code/API_definitions/traffic-influence.yaml)
 
 **Previous releases of the TrafficInfluence API available in [EdgeCloud](https://github.com/camaraproject/EdgeCloud).**
 

--- a/code/API_definitions/traffic-influence.yaml
+++ b/code/API_definitions/traffic-influence.yaml
@@ -329,7 +329,7 @@ info:
     error response if it is explicitly documented in the API.
     # FAQ's
     (FAQs will be added in a later version of the documentation)
-  version: wip
+  version: 0.10.0
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
@@ -341,7 +341,7 @@ externalDocs:
 #                                     Servers                              #
 ############################################################################
 servers:
-  - url: "{apiRoot}/traffic-influence/vwip"
+  - url: "{apiRoot}/traffic-influence/v0.10"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/Test_definitions/traffic-influence-postTrafficInfluence.feature
+++ b/code/Test_definitions/traffic-influence-postTrafficInfluence.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Traffic Influence API, vwip - Operation postTrafficInfluence and patchTrafficInfluence and getAllTrafficInfluences and deleteTrafficInfluence
+Feature: CAMARA Traffic Influence API, v0.10.0 - Operation postTrafficInfluence and patchTrafficInfluence and getAllTrafficInfluences and deleteTrafficInfluence
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -6,10 +6,10 @@ Feature: CAMARA Traffic Influence API, vwip - Operation postTrafficInfluence and
   # Testing assets:
   # * The optimal routing must be activated for any device
   #
-  # References to OAS spec schemas refer to schemas specifies in traffic-influence.yaml, version wip
+  # References to OAS spec schemas refer to schemas specifies in traffic-influence.yaml, version 0.10.0
 
   Background: Common traffic-influences setup
-    Given the path "/traffic-influence/vwip/traffic-influences"
+    Given the path "/traffic-influence/v0.10/traffic-influences"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/code/Test_definitions/traffic-influence-postTrafficInfluenceDevice.feature
+++ b/code/Test_definitions/traffic-influence-postTrafficInfluenceDevice.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Traffic Influence API, vwip - Operation postTrafficInfluenceDevice
+Feature: CAMARA Traffic Influence API, v0.10.0 - Operation postTrafficInfluenceDevice
   # Input to be provided by the implementation to the tester
   #
   # Implementation indications:
@@ -6,10 +6,10 @@ Feature: CAMARA Traffic Influence API, vwip - Operation postTrafficInfluenceDevi
   # Testing assets:
   # * The optimal routing for a device must be activated
   #
-  # References to OAS spec schemas refer to schemas specifies in traffic-influence.yaml, version wip
+  # References to OAS spec schemas refer to schemas specifies in traffic-influence.yaml, version 0.10.0
 
   Background: Common traffic-influence-devices setup
-    Given the path "/traffic-influence/vwip/traffic-influence-devices"
+    Given the path "/traffic-influence/v0.10/traffic-influence-devices"
     And the header "Content-Type" is set to "application/json"
     And the header "Authorization" is set to a valid access token
     And the header "x-correlator" complies with the schema at "#/components/schemas/XCorrelator"

--- a/documentation/API_documentation/traffic-influence-API-Readiness-Checklist.md
+++ b/documentation/API_documentation/traffic-influence-API-Readiness-Checklist.md
@@ -1,19 +1,19 @@
 # API Readiness Checklist
 
-Checklist for traffic-influence v0.10.0-rc.1 in r.1.2
+Checklist for traffic-influence v0.10.0 in r.1.3
 
 | Nr | API release assets  | alpha | release-candidate |  initial<br>public | stable<br> public | Status | Reference information |
 |----|----------------------------------------------|:-----:|:-----------------:|:-------:|:------:|:----:|:----|
 |  1 | API definition                               |   M   |         M         |    M    |    M   |   Y  | [link](/code/API_definitions/traffic-influence.yaml) |
-|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y  | [r3.2](https://github.com/camaraproject/Commonalities/releases/tag/r3.2) |
-|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y  | [r3.2](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.2) |
-|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y  | v0.10.0-rc.1 |
+|  2 | Design guidelines from Commonalities applied |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/Commonalities/releases/tag/r3.3) |
+|  3 | Guidelines from ICM applied                  |   O   |         M         |    M    |    M   |   Y  | [r3.3](https://github.com/camaraproject/IdentityAndConsentManagement/releases/tag/r3.3) |
+|  4 | API versioning convention applied            |   M   |         M         |    M    |    M   |   Y  | v0.10.0 |
 |  5 | API documentation                            |   M   |         M         |    M    |    M   |   Y  | inline in YAML |
 |  6 | User stories                                 |   O   |         O         |    O    |    M   |   Y  | [link](/documentation/API_documentation/traffic-influence-user-story-use-case-1.md) |
 |  7 | Basic API test cases & documentation         |   O   |         M         |    M    |    M   |   Y  | [Device](/code/Test_definitions/traffic-influence-device-test.feature), [Every User](/code/Test_definitions/traffic-influence-test.feature) |
 |  8 | Enhanced API test cases & documentation      |   O   |         O         |    O    |    M   |   N  |  |
 |  9 | Test result statement                        |   O   |         O         |    O    |    M   |   N  |      |
-| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y  | r1.2 |
+| 10 | API release numbering convention applied     |   M   |         M         |    M    |    M   |   Y  | r1.3 |
 | 11 | Change log updated                           |   M   |         M         |    M    |    M   |   Y  | [link](/CHANGELOG.md) |
 | 12 | Previous public-release was certified        |   O   |         O         |    O    |    M   |   N  |      |
 | 13 | API description (for marketing)              |   O   |         O         |    M    |    M   |   Y  | [wiki link](https://lf-camaraproject.atlassian.net/wiki/x/d4JlBQ) |
@@ -29,3 +29,4 @@ To fill the checklist:
 Note: the checklists of a public API version and of its preceding release-candidate API version can be the same.
 
 The documentation for the content of the checklist is here: see API Readiness Checklist section in the [API Release Process](https://lf-camaraproject.atlassian.net/wiki/x/jine).
+


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
This is the M4 PR for the public version of the TI API, for the Fall25 Meta Release. The PR changes the API version from WIP to 0.10.0 ad provides the updated README.md and CHANGELOG.md files.

#### Which issue(s) this PR fixes
https://github.com/camaraproject/TrafficInfluence/issues/67